### PR TITLE
adding the "patterns for enlivening small groups"

### DIFF
--- a/crewing.md
+++ b/crewing.md
@@ -4,17 +4,27 @@ description: Methods for people to support each other in small groups (less than
 
 # Crewing
 
-These methods are primarily designed for people outside of a formal organisational context, e.g. freelancers and activists. However many of them may migrate smoothly into organisations. The important factor is that people support each other in peer-to-peer relationships of mutual aid.
+These methods are primarily designed for people outside of a formal organisational context, e.g. freelancers and activists. However many of them may migrate smoothly into organisations. These are ways for people to support each other in peer-to-peer relationships of mutual aid.
 
-* [Feelz Circle](http://emotionalanarchism.com/how-to-form-a-radical-feelz-circle/): 3 processes for sharing emotional care between friends/ comrades/ lovers
+In some Microsolidarity channels, there are folks working to illuminate [core patterns or principles](https://drive.google.com/drive/u/1/folders/1uUQ7KJuhle71Oh5_2iuMfMOon4JYJfX2) that support crews to successfully form, generate value for their participants, and gracefully end such that the participants can go on to join or start other groups (you can also think of this as composting, and there's an impulse to get better at 'sunsetting' our groups and projects). 
+
+* There's an intention to write a blog that explains these points alongside concrete examples that will make it more practical, but for now you can hear us describe them alongside some context of early experiments in the [recording of the Crews/ Pods open space at Enspiral Summer Fest 2019](https://www.microsolidarity.cc/discussing/enspiral-summer-retreat-feb-2019).
+
+---
+
+Here's some specific methods that groups have used:
+
 * [Care Pod](https://docs.google.com/document/d/1pFPbxmzf41zsHS0pMExvPqz9Pi6SMFXeFHJ8_Eb96EI/edit?ts=5bdf0475) personal-and-professional development in small groups, a new practice in development at Enspiral, based on Intentional Change Theory
-* [Stewardship](https://loomio.coop/stewarding.html) peer support system for Partnerships
 * [The Elephants](https://medium.com/things-ive-written/the-elephants-182870501589) long term personal development for Crews
 * If you have more to add to this list, please [contribute](contributing.md) :\)
+* [Feelz Circle](http://emotionalanarchism.com/how-to-form-a-radical-feelz-circle/): 3 processes for sharing emotional care between friends/ comrades/ lovers
+* [Stewardship](https://loomio.coop/stewarding.html) peer support system for Partnerships
+
+---
 
 ### Forming
 
-How is Crew formed? We're not sure. Rich's original [proposal](proposal.md) suggests the best way to meet your Crewmates is in a Congregation: a larger gathering of people with some shared values and medium-high trust. 
+How is Crew formed? We're not sure. Rich's original [proposal](proposal.md) suggests the best way to meet your Crew-mates is in a Congregation: a larger gathering of people with some shared values and medium-high trust. The core patterns linked above may help, but there's many experiments to be done.
 
 🔈[In this podcast](https://anchor.fm/emerge/episodes/Ria-Baeck---Emergent-Collective-Practice-and-Applied-Presence-e2qppp/a-a83fd7) with Daniel Thorson, Ria Baeck suggests the best place to start is at home, with a few guests gathered around a compelling question.
 


### PR DESCRIPTION
plus minor formatting, alphabetising list, and a tiny spelling thing.

_aside_: I don't really feel like the Stewardship article fits here, even if I can imagine an article about Stewarding that would...; as described in the loomio handbook it jcomes across as a practice for dyads, livelihood pods, or Congregations (to me). And while livelihood pods share some characteristics with Crews I think that the distinction around how often retro/ opt-in (again) happen are an important distinction that matters in this case.