### PR TITLE
group size

### DIFF
--- a/crewing/README.md
+++ b/crewing/README.md
@@ -1,5 +1,5 @@
 ---
-description: Methods for people to support each other in small groups (less than 8)
+description: Methods for people to support each other in small groups (less than 8, although some work well with slightly larger groups too)
 ---
 
 # Crewing


### PR DESCRIPTION
I think quite a few of these groups would very likely work well with groups larger than 8 too, and I'm concerned people will come to this page wanting to do something for say 12 people and then decide to not read any further, so I've added "although some work well with slightly larger groups too". But perhaps another idea would be to simply remove the reference to "less than 8" and let people self-define in their heads what they mean by a small group?